### PR TITLE
[f] Exception matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ expect([1,2,3]).to.not_contain(4)
 expect({'foo': 'bar'}).to.exclude('baz')
 ```
 
-### throw
+#### throw
 
 Asserts that the target throws an exception
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ Asserts that the target throws an exception
 
 ``` python
 expect(lambda: raise_exception(...)).to.throw(Exception)
-expect(lambda: raise_exception(...)).throws(Exception)
 expect(any_callable).to.throw(Exception)
 ```
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Asserts that the target throw an exception
 
 ``` python
 expect(lambda: raise_exception(...)).to.throw(Exception)
+expect(lambda: raise_exception(...)).throws(Exception)
+expect(any_callable).to.throw(Exception)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ expect([1,2,3]).to.not_contain(4)
 expect({'foo': 'bar'}).to.exclude('baz')
 ```
 
+### throw/raise
+
+Asserts that the target throw an exception
+
+``` python
+expect(lambda: raise_exception(...)).to.raise(Exception)
+```
+
 ### Language chains
 
 In order to write more readable assertions, there are a few

--- a/README.md
+++ b/README.md
@@ -245,13 +245,14 @@ expect([1,2,3]).to.not_contain(4)
 expect({'foo': 'bar'}).to.exclude('baz')
 ```
 
-### throw/raise
+### throw
 
 Asserts that the target throw an exception
 
 ``` python
-expect(lambda: raise_exception(...)).to.raise(Exception)
+expect(lambda: raise_exception(...)).to.throw(Exception)
 ```
+
 
 ### Language chains
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ expect({'foo': 'bar'}).to.exclude('baz')
 
 ### throw
 
-Asserts that the target throw an exception
+Asserts that the target throws an exception
 
 ``` python
 expect(lambda: raise_exception(...)).to.throw(Exception)

--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ expect(lambda: raise_exception(...)).to.throw(Exception)
 expect(any_callable).to.throw(Exception)
 ```
 
-
 ### Language chains
 
 In order to write more readable assertions, there are a few

--- a/robber/matchers/exception.py
+++ b/robber/matchers/exception.py
@@ -7,27 +7,28 @@ class ExceptionMatcher(Base):
     expect(lambda: call_something(with_some_params)).to.throw(any_exception)
     """
     @property
-    def _raised(self):
-        raised = None
-
-        if not callable(self.actual):
-            raise TypeError('{actual} is not callable'.format(actual=self.actual))
-
+    def raised(self):
         try:
-            self.actual()
-        except BaseException as raised:
-            return raised
+            return self._raised
+        except AttributeError:
+            if not callable(self.actual):
+                raise TypeError('{actual} is not callable'.format(actual=self.actual))
+
+            try:
+                self.actual()
+            except BaseException as raised:
+                self._raised = raised
+                return self._raised
 
     def matches(self):
-        return isinstance(self._raised, self.expected)
+        return isinstance(self.raised, self.expected)
 
     def failure_message(self):
-        if self._raised:
-            got = self._raised.__class__.__name__
+        if self.raised:
+            got = self.raised.__class__.__name__
         else:
             got = 'nothing'
 
         return 'Expected %s, got %s' % (self.expected.__name__, got)
 
 expect.register('throw', ExceptionMatcher)
-expect.register('throws', ExceptionMatcher)

--- a/robber/matchers/exception.py
+++ b/robber/matchers/exception.py
@@ -29,4 +29,4 @@ class ExceptionMatcher(Base):
 
         return 'Expected %s, got %s' % (self.expected.__name__, got)
 
-expect.register('raise', ExceptionMatcher)
+expect.register('throw', ExceptionMatcher)

--- a/robber/matchers/exception.py
+++ b/robber/matchers/exception.py
@@ -1,0 +1,32 @@
+from robber import expect
+from robber.matchers.base import Base
+
+
+class ExceptionMatcher(Base):
+    """
+    expect(lambda: call_something(with_some_params)).to.throw(any_exception)
+    """
+    @property
+    def _raised(self):
+        raised = None
+
+        if not callable(self.actual):
+            raise TypeError('{actual} is not callable'.format(actual=self.actual))
+
+        try:
+            self.actual()
+        except BaseException as raised:
+            return raised
+
+    def matches(self):
+        return isinstance(self._raised, self.expected)
+
+    def failure_message(self):
+        if self._raised:
+            got = self._raised.__class__.__name__
+        else:
+            got = 'nothing'
+
+        return 'Expected %s, got %s' % (self.expected.__name__, got)
+
+expect.register('raise', ExceptionMatcher)

--- a/robber/matchers/exception.py
+++ b/robber/matchers/exception.py
@@ -30,3 +30,4 @@ class ExceptionMatcher(Base):
         return 'Expected %s, got %s' % (self.expected.__name__, got)
 
 expect.register('throw', ExceptionMatcher)
+expect.register('throws', ExceptionMatcher)

--- a/tests/matchers/test_exception.py
+++ b/tests/matchers/test_exception.py
@@ -1,0 +1,26 @@
+import unittest
+
+from robber import expect
+from robber.matchers.exception import ExceptionMatcher
+
+
+class TestExceptionMatcher(unittest.TestCase):
+    def raise_exception(self, ex):
+        raise ex
+
+    def test_matches(self):
+        expect(ExceptionMatcher(lambda: 1 / 0, ZeroDivisionError).matches()) == True
+        expect(ExceptionMatcher(lambda: None, Exception).matches()) == False
+
+    def test_actual_is_not_callable(self):
+        self.assertRaises(TypeError, ExceptionMatcher(None, Exception).matches)
+
+    def test_failure_message_with_wrong_exception(self):
+        exception_raised = ExceptionMatcher(lambda: self.raise_exception(TypeError()), ZeroDivisionError)
+        message = exception_raised.failure_message()
+        expect(message) == 'Expected ZeroDivisionError, got TypeError'
+
+    def test_failure_message_with_no_exception_was_raised(self):
+        no_exception = ExceptionMatcher(lambda: None, Exception)
+        message = no_exception.failure_message()
+        expect(message) == 'Expected Exception, got nothing'


### PR DESCRIPTION
## Description
- Add exception matchers:

``` python
expect(lambda: raised_exception(something)).to.throw(something)
expect(callable).to.throw(something)
```
## Note 
- Here's what happen with `sure`:

``` python
func.when.called_with(args).should.raises(exception)
```

or `expect` syntax:

``` python
expect(func).when.called_with(args).to.raises(exception)
```
- Issues?
  - Unnecessary extra chaining
  - Not really an obvious way
- So, I decided to write it another way. `lambda` seems to be great candidate:
  - The syntax is pretty readable
  - Pythonic and more obvious way to invoke a callable 
- Limitation:
  - We can expect 1 statement only (but the same thing happens with `sure`) or any callable
  - `lambda` can't raise the exception in its scope, we can over this by exposing a function like `raise_exception`, but till now, I can't find any use-cases which we need to test raise exception directly, except the unit-tests for this feature. So, we can consider it later.
## How to test
- Unit tests were written, you can check it and `README.md` for documentation
