### PR TITLE
Add `change, by` chaining matchers

### DIFF
--- a/robber/matchers/base.py
+++ b/robber/matchers/base.py
@@ -8,10 +8,11 @@ class Base:
     idea to extend it, as well.
     """
 
-    def __init__(self, actual, expected = None, *args):
+    def __init__(self, actual, expected=None, *args):
         self.actual = actual
         self.expected = expected
         self.args = args
+        self.message = None
 
     def fail_with(self, message):
         self.message = message

--- a/robber/matchers/numbers.py
+++ b/robber/matchers/numbers.py
@@ -49,13 +49,13 @@ class Change(Base):
         changed = self.callable(self.obj) - self.obj
 
         if changed != amount:
-            message = self.message or self.failure_message(self.obj, amount, changed)
+            message = self.message or self.failure_message(self.callable.__name__, self.obj, amount, changed)
             raise BadExpectation(message)
 
         return expect(self.obj)
 
-    def failure_message(self, obj, changed, got):
-        return 'Expected %g to be changed by %g, but was changed by %g' % (obj, changed, got)
+    def failure_message(self, callable_name, obj, changed, got):
+        return 'Expect function %s to change %g by %g, but was changed by %g' % (callable_name, obj, changed, got)
 
 
 expect.register('above', Above)

--- a/robber/matchers/numbers.py
+++ b/robber/matchers/numbers.py
@@ -1,6 +1,6 @@
+from robber import BadExpectation
 from robber import expect
 from robber.matchers.base import Base
-
 
 class Above(Base):
     """
@@ -34,6 +34,30 @@ class Within(Base):
     def failure_message(self):
         return 'Expected %g to be within %g and %g' % (self.actual, self.expected, self.args[0])
 
+
+class Change(Base):
+    def __init__(self, callable, obj=None, *args):
+        self.callable = callable
+        self.obj = obj
+        self.args = args
+        self.message = None
+
+    def match(self):
+        return self
+
+    def by(self, amount=0):
+        changed = self.callable(self.obj) - self.obj
+
+        if changed != amount:
+            message = self.message or self.failure_message(self.obj, amount, changed)
+            raise BadExpectation(message)
+
+        return expect(self.obj)
+
+    def failure_message(self, obj, changed, got):
+        return 'Expected %g to be changed by %g, but was changed by %g' % (obj, changed, got)
+
+
 expect.register('above', Above)
 expect.register('below', Below)
 expect.register('more_than', Above)
@@ -41,3 +65,4 @@ expect.register('less_than', Below)
 expect.register('greater_than', Above)
 expect.register('smaller_than', Below)
 expect.register('within', Within)
+expect.register('change', Change)

--- a/tests/matchers/test_numbers.py
+++ b/tests/matchers/test_numbers.py
@@ -43,4 +43,9 @@ class TestChange(unittest.TestCase):
         expect(Change(lambda x: x + 2, 1).by(2)) == True
 
     def test_change_by_raise_exception(self):
-        self.assertRaises(BadExpectation, Change(lambda x: x + 2, 1).by, 1)
+        def increase_by_2(x):
+            return x + 2
+
+        with self.assertRaises(BadExpectation) as cm:
+            Change(increase_by_2, 1).by(1)
+        self.assertEqual(cm.exception.message, 'Expect function increase_by_2 to change 1 by 1, but was changed by 2')

--- a/tests/matchers/test_numbers.py
+++ b/tests/matchers/test_numbers.py
@@ -1,6 +1,6 @@
 import unittest
-from robber import expect
-from robber.matchers.numbers import Above, Below, Within
+from robber import expect, BadExpectation
+from robber.matchers.numbers import Above, Below, Within, Change
 
 class TestAbove(unittest.TestCase):
     def test_matches(self):
@@ -37,3 +37,10 @@ class TestWithin(unittest.TestCase):
 
     def test_register(self):
         expect(expect.matcher('within')) == Within
+
+class TestChange(unittest.TestCase):
+    def test_change_by_success(self):
+        expect(Change(lambda x: x + 2, 1).by(2)) == True
+
+    def test_change_by_raise_exception(self):
+        self.assertRaises(BadExpectation, Change(lambda x: x + 2, 1).by, 1)

--- a/tests/matchers/test_numbers.py
+++ b/tests/matchers/test_numbers.py
@@ -45,7 +45,7 @@ class TestChange(unittest.TestCase):
     def test_change_by_raise_exception(self):
         def increase_by_2(x):
             return x + 2
-
-        with self.assertRaises(BadExpectation) as cm:
+        try:
             Change(increase_by_2, 1).by(1)
-        self.assertEqual(cm.exception.message, 'Expect function increase_by_2 to change 1 by 1, but was changed by 2')
+        except BadExpectation as exception:
+            self.assertEqual(exception.message, 'Expect function increase_by_2 to change 1 by 1, but was changed by 2')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -196,3 +196,10 @@ class TestIntegration(unittest.TestCase):
             expect(e.message) == 'Something went wrong'
         else:
             raise BadExpectation('must fail with custom message')
+
+    def test_change_by_success(self):
+        expect(lambda x: x + 1).to.change(0).by(1)
+
+    @must_fail
+    def test_change_by_failure(self):
+        expect(lambda x: x + 1).to.change(0).by(2)


### PR DESCRIPTION
Examples chaining matchers, e.g:
`expect(lambda x: x+1).to.change(1).by(1)`

It might address this issue: https://github.com/EastAgile/robber.py/issues/4