### PR TITLE
[f] Make eq failure message clearer

### DIFF
--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -13,7 +13,12 @@ class Equal(Base):
         return self.actual == self.expected
 
     def failure_message(self):
-        return 'Expected "%s" to equal "%s"' % (self.actual, self.expected)
+        return 'Expected {actual_type}("{actual_value}") to equal {expected_type}("{expected_value}")'.format(
+            actual_type=type(self.actual).__name__,
+            actual_value=self.actual,
+            expected_type=type(self.expected).__name__,
+            expected_value=self.expected,
+        )
 
 class NotEqual(Base):
     """

--- a/tests/matchers/test_equal.py
+++ b/tests/matchers/test_equal.py
@@ -8,9 +8,9 @@ class TestEqual:
         expect(Equal(1, 2).matches()) == False
 
     def test_failure_message(self):
-        equal = Equal('actual', 'expected')
+        equal = Equal('123', 123)
         message = equal.failure_message()
-        expect(message) == 'Expected "actual" to equal "expected"'
+        expect(message) == 'Expected str("123") to equal int("123")'
 
     def test_register(self):
         expect(expect.matcher('eq')) == Equal


### PR DESCRIPTION
Issue: https://github.com/EastAgile/robber.py/issues/30

Change the eq failure message format to this:
```python
Expected type("value") to equal type("value"))
```
For example:
```python
expect(123).to.be.eq('123')
```
Returns the message:
```python
BadExpectation: 'Expected int("123") to equal str("123")'
```