### PR TITLE
[f] to.be.callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ expect(lambda: raise_exception(...)).to.throw(Exception)
 expect(any_callable).to.throw(Exception)
 ```
 
+#### callable
+
+Asserts that a object is callable 
+
+``` python
+expect(object).to.be.callable
+```
+
 ### Language chains
 
 In order to write more readable assertions, there are a few

--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ expect(lambda: raise_exception(...)).to.throw(Exception)
 expect(any_callable).to.throw(Exception)
 ```
 
+#### called
+
+Asserts that a mock has been called
+
+``` python
+expect(mock).to.be.called
+```
+
 #### callable
 
 Asserts that a object is callable 

--- a/robber/matchers/__init__.py
+++ b/robber/matchers/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
 # from robber.matchers.base import *
 from robber.matchers.boolean import *
 from robber.matchers.called import *
+from robber.matchers.callable import *
 from robber.matchers.contain import *
 from robber.matchers.equal import *
 from robber.matchers.exception import *

--- a/robber/matchers/callable.py
+++ b/robber/matchers/callable.py
@@ -8,7 +8,7 @@ class Callable(Base):
     """
 
     def matches(self):
-        return hasattr(self.actual, '__call__')
+        return callable(self.actual)
 
     def failure_message(self):
         return 'Expected {actual} to be callable'.format(actual=self.actual)

--- a/robber/matchers/callable.py
+++ b/robber/matchers/callable.py
@@ -1,0 +1,18 @@
+from robber import expect
+from robber.matchers.base import Base
+
+
+class Callable(Base):
+    """
+    expect(function).to.be.callable()
+    """
+
+    def matches(self):
+        return hasattr(self.actual, '__call__')
+
+    def failure_message(self):
+        return 'Expected {actual} to be callable'.format(actual=self.actual)
+
+
+expect.register('callable', Callable)
+expect.register('__callable__', Callable)

--- a/tests/matchers/test_callable.py
+++ b/tests/matchers/test_callable.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from robber import expect
+from robber.matchers.callable import Callable
+
+
+class TestCallable(TestCase):
+    def test_matches(self):
+        def a():
+            pass
+
+        expect(Callable(a).matches()) == True
+
+    def test_failure_message(self):
+        callable = Callable("a")
+        message = callable.failure_message()
+        expect(message) == 'Expected a to be callable'
+
+    def test_register(self):
+        expect(expect.matcher('callable')) == Callable
+        expect(expect.matcher('__callable__')) == Callable

--- a/tests/matchers/test_callable.py
+++ b/tests/matchers/test_callable.py
@@ -12,8 +12,8 @@ class TestCallable(TestCase):
         expect(Callable(a).matches()) == True
 
     def test_failure_message(self):
-        callable = Callable("a")
-        message = callable.failure_message()
+        assert_callable = Callable("a")
+        message = assert_callable.failure_message()
         expect(message) == 'Expected a to be callable'
 
     def test_register(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -228,3 +228,13 @@ class TestIntegration(unittest.TestCase):
     def test_not_a_mock(self):
         self.assertRaises(TypeError, expect('a').to.be.called)
         self.assertRaises(TypeError, expect(1).to.be.called)
+
+    def test_callable_success(self):
+        def a():
+            pass
+        expect(a).to.be.callable()
+
+    @must_fail
+    def test_callable_failure(self):
+        expect("a").to.be.callable()
+        expect(1).to.be.callable()


### PR DESCRIPTION
Issue: https://github.com/EastAgile/robber.py/issues/20

We will add this expectation to our code base:

```python
expect(object).to.be.callable()
```