### PR TITLE
[f] Add expect(str).to.similar_to(str)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ expect(mock).to.have.been.ever_called_with(*args, **kwargs)
 expect(mock).to.have.any_call(*args, **kwargs)
 ```
 
+#### similar_to
+
+Asserts that two strings are similar.
+
+```python
+expect('  a  CA t   ').to.be.similar_to('a c A  t')
+```
+
 ### Language chains
 
 In order to write more readable assertions, there are a few

--- a/robber/matchers/__init__.py
+++ b/robber/matchers/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     'numbers',
     'regexp',
     'respond_to',
+    'similar_to',
     'truthy',
     'types',
 ]
@@ -34,5 +35,6 @@ from robber.matchers.length import *  # noqa F403
 from robber.matchers.numbers import *  # noqa F403
 from robber.matchers.regexp import *  # noqa F403
 from robber.matchers.respond_to import *  # noqa F403
+from robber.matchers.similar_to import *  # noqa F403
 from robber.matchers.truthy import *  # noqa F403
 from robber.matchers.types import *  # noqa F403

--- a/robber/matchers/similar_to.py
+++ b/robber/matchers/similar_to.py
@@ -1,0 +1,27 @@
+import re
+
+from robber import expect
+from robber.explanation import Explanation
+from robber.matchers.base import Base
+
+
+class SimilarTo(Base):
+    """
+    expect('a   StRing').to.be.similar_to('a string')
+    """
+
+    def matches(self):
+        try:
+            standardized_actual = re.sub('\s', '', self.actual).lower()
+            standardized_expected = re.sub('\s', '', self.expected).lower()
+        except TypeError:
+            raise TypeError('Expected two strings')
+
+        return standardized_actual == standardized_expected
+
+    @property
+    def explanation(self):
+        return Explanation(self.actual, self.is_negative, 'be similar to', self.expected)
+
+
+expect.register('similar_to', SimilarTo)

--- a/tests/integrations/test_similar_to.py
+++ b/tests/integrations/test_similar_to.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from robber import expect
+from tests import must_fail
+
+
+class TestSimilarToIntegrations(TestCase):
+    def test_similar_to_success(self):
+        expect('  a  CA t   ').to.be.similar_to('a c A  t')
+
+    @must_fail
+    def test_similar_to_failure(self):
+        expect('a cat').to.be.similar_to('a dog')
+
+    def test_not_to_similar_to_success(self):
+        expect('a cat').not_to.be.similar_to('a dog')
+
+    @must_fail
+    def test_not_to_similar_to_failure(self):
+        expect('  a  CA t   ').not_to.be.similar_to('a c A  t')

--- a/tests/matchers/test_similar_to.py
+++ b/tests/matchers/test_similar_to.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+from robber import expect
+from robber.matchers.similar_to import SimilarTo
+
+
+class TestSimilarTo(TestCase):
+    def test_matches(self):
+        expect(SimilarTo('  a  CA t   ', 'a c A  t').matches()).to.eq(True)
+        expect(SimilarTo('a cat', 'a dog').matches()).to.eq(False)
+
+    def test_explanation_message(self):
+        similar_to = SimilarTo('a cat', 'a dog')
+        message = similar_to.explanation.message
+        expect(message).to.be.similar_to("""
+A = a cat
+B = a dog
+Expected A to be similar to B
+""")
+
+    def test_negative_explanation_message(self):
+        similar_to = SimilarTo('  a  CA t   ', 'a c A  t', is_negative=True)
+        message = similar_to.explanation.message
+        expect(message).to.be.similar_to("""
+A =   a  CA t
+B = a c A  t
+Expected A not to be similar to B
+""")
+
+    def test_not_strings(self):
+        self.assertRaises(TypeError, SimilarTo(1, '1').matches)
+        self.assertRaises(TypeError, SimilarTo('1', [1]).matches)
+
+    def test_register(self):
+        expect(expect.matcher('similar_to')) == SimilarTo


### PR DESCRIPTION
### Related issue
https://github.com/EastAgile/robber.py/issues/37

### Description
Let's add this expectation to our code base:

```python
expect(str).to.be.similar_to(str)
```
This asserts if two strings are similar. `similar` means after removing all the spaces and got lowercased, the two strings are exactly the same 

### Usage
```python
expect('  a  CA t   ').to.be.similar_to('a c A  t')
```
