### PR TITLE
[f] Contain/exclude multiple args

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ expect(2).to.be.within(0, 2)
 
 Asserts that the target contains an element, or a key:
 ```python
-expect([1,2,3]).to.contain(2)
-expect({'foo': 'bar'}).to.contain('foo')
+expect([1,2,3]).to.contain(1, 2, 3)
+expect({'foo': 'bar', 'foo1': 'bar1'}).to.contain('foo', 'foo1')
 ```
 
 #### exclude

--- a/robber/matchers/contain.py
+++ b/robber/matchers/contain.py
@@ -14,23 +14,35 @@ class Contain(Base):
         expected_list.insert(0, self.expected)
 
         if not self.is_negative:
-            excluded_args = set(expected_list).difference(self.actual)
-            try:
-                self.expected_arg = excluded_args.pop()
-            except KeyError:
-                return True
-            else:
-                return False
+            included, self.expected_arg = self._contain(self.actual, expected_list)
+            return included
 
         else:
+            excluded, self.expected_arg = self._exclude(self.actual, expected_list)
             # As this is the negative case, we have to flip the return value.
-            included_args = set(expected_list).intersection(self.actual)
-            try:
-                self.expected_arg = included_args.pop()
-            except KeyError:
-                return False
-            else:
-                return True
+            return not excluded
+
+    @staticmethod
+    def _contain(source_list, target_list):
+        # checks if source_list includes target_list and returns the first excluded element if yes
+        excluded_elements = set(target_list).difference(source_list)
+        try:
+            first_excluded_element = excluded_elements.pop()
+        except KeyError:
+            return True, None
+        else:
+            return False, first_excluded_element
+
+    @staticmethod
+    def _exclude(source_list, target_list):
+        # checks if source_list excludes target_list and returns the first included element if yes
+        included_elements = set(target_list).intersection(source_list)
+        try:
+            first_included_element = included_elements.pop()
+        except KeyError:
+            return True, None
+        else:
+            return False, first_included_element
 
     @property
     def explanation(self):

--- a/robber/matchers/contain.py
+++ b/robber/matchers/contain.py
@@ -5,16 +5,33 @@ from robber.matchers.base import Base
 
 class Contain(Base):
     """
-    expect({'key': value}).to.contain('key')
-    expect([1, 2, 3]).to.contain(2)
+    expect({'key': value}).to.contain('key 1', 'key 2', 'key n')
+    expect([1, 2, 3]).to.contain(1, 2, 3)
     """
 
     def matches(self):
-        return self.expected in self.actual
+        expected_list = list(self.args)
+        expected_list.insert(0, self.expected)
+
+        if not self.is_negative:
+            for expected in expected_list:
+                if expected not in self.actual:
+                    self.expected_arg = expected
+                    return False
+
+            return True
+        else:
+            # As this is the negative case, we have to flip the return value.
+            for expected in expected_list:
+                if expected in self.actual:
+                    self.expected_arg = expected
+                    return True
+
+            return False
 
     @property
     def explanation(self):
-        return Explanation(self.actual, self.is_negative, 'contain', self.expected, negative_action='exclude')
+        return Explanation(self.actual, self.is_negative, 'contain', self.expected_arg, negative_action='exclude')
 
 
 expect.register('contain', Contain)

--- a/robber/matchers/contain.py
+++ b/robber/matchers/contain.py
@@ -14,20 +14,23 @@ class Contain(Base):
         expected_list.insert(0, self.expected)
 
         if not self.is_negative:
-            for expected in expected_list:
-                if expected not in self.actual:
-                    self.expected_arg = expected
-                    return False
+            excluded_args = set(expected_list).difference(self.actual)
+            try:
+                self.expected_arg = excluded_args.pop()
+            except KeyError:
+                return True
+            else:
+                return False
 
-            return True
         else:
             # As this is the negative case, we have to flip the return value.
-            for expected in expected_list:
-                if expected in self.actual:
-                    self.expected_arg = expected
-                    return True
-
-            return False
+            included_args = set(expected_list).intersection(self.actual)
+            try:
+                self.expected_arg = included_args.pop()
+            except KeyError:
+                return False
+            else:
+                return True
 
     @property
     def explanation(self):

--- a/robber/matchers/contain.py
+++ b/robber/matchers/contain.py
@@ -14,35 +14,24 @@ class Contain(Base):
         expected_list.insert(0, self.expected)
 
         if not self.is_negative:
-            included, self.expected_arg = self._contain(self.actual, expected_list)
-            return included
+            # run when contain chain triggered
+            elements = set(expected_list).difference(self.actual)
 
         else:
-            excluded, self.expected_arg = self._exclude(self.actual, expected_list)
-            # As this is the negative case, we have to flip the return value.
-            return not excluded
+            # run when not contain/excluded chain triggered
+            elements = set(expected_list).intersection(self.actual)
 
-    @staticmethod
-    def _contain(source_list, target_list):
-        # checks if source_list includes target_list and returns the first excluded element if yes
-        excluded_elements = set(target_list).difference(source_list)
-        try:
-            first_excluded_element = excluded_elements.pop()
-        except KeyError:
-            return True, None
-        else:
-            return False, first_excluded_element
+        existed, self.expected_arg = self._get_first(elements)
+        return existed is self.is_negative
 
     @staticmethod
-    def _exclude(source_list, target_list):
-        # checks if source_list excludes target_list and returns the first included element if yes
-        included_elements = set(target_list).intersection(source_list)
+    def _get_first(elements):
         try:
-            first_included_element = included_elements.pop()
+            first_element = elements.pop()
         except KeyError:
-            return True, None
+            return False, None
         else:
-            return False, first_included_element
+            return True, first_element
 
     @property
     def explanation(self):

--- a/tests/integrations/test_contain.py
+++ b/tests/integrations/test_contain.py
@@ -19,6 +19,20 @@ class TestContainIntegrations(TestCase):
     def test_not_contain_failure(self):
         expect([1, 2, 3]).not_to.contain(2)
 
+    def test_contain_multiple_value(self):
+        expect([1, 2, 3]).to.contain(1, 2)
+
+    @must_fail
+    def test_contain_multiple_value_failure(self):
+        expect([1, 2, 3]).to.contain(1, 4)
+
+    def test_not_contain_multiple_value(self):
+        expect([1, 2, 3]).not_to.contain(4, 5)
+
+    @must_fail
+    def test_not_contain_multiple_value_failure(self):
+        expect([1, 2, 3]).not_to.contain(1, 4)
+
 
 class TestExcludeIntegrations(TestCase):
     def test_exclude_success(self):
@@ -34,3 +48,17 @@ class TestExcludeIntegrations(TestCase):
     @must_fail
     def test_not_exclude_failure(self):
         expect([1, 2, 3]).not_to.exclude(0)
+
+    def test_exclude_multiple_value(self):
+        expect([1, 2, 3]).to.exclude(4, 5)
+
+    @must_fail
+    def test_exclude_multiple_value_failure(self):
+        expect([1, 2, 3]).to.exclude(1, 2)
+
+    def test_not_exclude_multiple_value(self):
+        expect([1, 2, 3]).not_to.exclude(1, 2)
+
+    @must_fail
+    def test_not_exclude_multiple_value_failure(self):
+        expect([1, 2, 3]).not_to.exclude(1, 4)

--- a/tests/matchers/test_contain.py
+++ b/tests/matchers/test_contain.py
@@ -1,10 +1,10 @@
-import unittest
+from unittest import TestCase
 
 from robber import expect
 from robber.matchers.contain import Contain
 
 
-class TestContain(unittest.TestCase):
+class TestContain(TestCase):
     def test_matches(self):
         expect(Contain({'key': 'value'}, 'key').matches()).to.eq(True)
         expect(Contain([1, 2, 3], 2).matches()).to.eq(True)
@@ -57,3 +57,18 @@ Expected A to exclude B
     def test_register(self):
         expect(expect.matcher('contain')) == Contain
         expect(expect.matcher('exclude')) == Contain
+
+
+class TestGetFirst(TestCase):
+    def test_with_empty_set(self):
+        success, first = Contain._get_first(set())
+
+        expect(success).to.eq(False)
+        expect(first).to.eq(None)
+
+    def test_with_normal_set(self):
+        # We need to support Python 2.6, so set literal cannot be used here.
+        success, first = Contain._get_first(set([1, 2]))
+
+        expect(success).to.eq(True)
+        expect(first).to.eq(1)

--- a/tests/matchers/test_contain.py
+++ b/tests/matchers/test_contain.py
@@ -16,6 +16,17 @@ class TestContain(unittest.TestCase):
 
     def test_explanation_message(self):
         contain = Contain([1, 2, 3], 4)
+        contain.matches()
+        message = contain.explanation.message
+        expect(message) == """
+A = [1, 2, 3]
+B = 4
+Expected A to contain B
+"""
+
+    def test_explanation_message_with_multiple_args(self):
+        contain = Contain([1, 2, 3], 4, False, 5)
+        contain.matches()
         message = contain.explanation.message
         expect(message) == """
 A = [1, 2, 3]
@@ -25,6 +36,17 @@ Expected A to contain B
 
     def test_negative_explanation_message(self):
         contain = Contain([1, 2, 3], 2, is_negative=True)
+        contain.matches()
+        message = contain.explanation.message
+        expect(message) == """
+A = [1, 2, 3]
+B = 2
+Expected A to exclude B
+"""
+
+    def test_negative_explanation_message_with_multiple_args(self):
+        contain = Contain([1, 2, 3], 2, True, 3)
+        contain.matches()
         message = contain.explanation.message
         expect(message) == """
 A = [1, 2, 3]


### PR DESCRIPTION
### Related issue
https://github.com/EastAgile/robber.py/issues/11

### Description
Now contain/exclude can take multiple args

```python
expect(a).to.contain(x, y, z)
expect(a).to.exclude(x, y, z)
```