### PR TITLE
[f] Add throw_exactly chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,22 @@ expect({'foo': 'bar'}).to.exclude('baz')
 
 #### throw
 
-Asserts that the target throws an exception
+Asserts that the target throws an exception (or its parent)
 
 ```python
 expect(lambda: raise_exception(...)).to.throw(Exception)
+expect(lambda: raise_exception(...)).to.throw(ParentException)
 expect(any_callable).to.throw(Exception)
+expect(any_callable).to.throw(ParentException)
+```
+
+#### throw_exactly
+
+Asserts that the target throws exactly an exception (not its parent)
+
+```python
+expect(lambda: raise_exception(...)).to.throw_exactly(Exception)
+expect(any_callable).to.throw_exactly(Exception)
 ```
 
 #### called

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ expect({'foo': 'bar'}).to.exclude('baz')
 
 #### throw
 
-Asserts that the target throws an exception (or its parent)
+Asserts that the target throws an exception (or its subclass)
 
 ```python
 expect(lambda: raise_exception(...)).to.throw(Exception)
@@ -231,7 +231,7 @@ expect(any_callable).to.throw(ParentException)
 
 #### throw_exactly
 
-Asserts that the target throws exactly an exception (not its parent)
+Asserts that the target throws exactly an exception (not its subclass)
 
 ```python
 expect(lambda: raise_exception(...)).to.throw_exactly(Exception)

--- a/robber/matchers/exception.py
+++ b/robber/matchers/exception.py
@@ -26,13 +26,31 @@ class ExceptionMatcher(Base):
         return isinstance(self.raised, self.expected)
 
     @property
+    def verb(self):
+        return 'be raised'
+
+    @property
     def explanation(self):
         if self.raised:
             got = self.raised.__class__.__name__
         else:
             got = 'nothing'
 
-        return Explanation(self.expected.__name__, self.is_negative, 'be raised', other=got)
+        return Explanation(self.expected.__name__, self.is_negative, self.verb, other=got)
+
+
+class ExactExceptionMatcher(ExceptionMatcher):
+    """
+    expect(lambda: call_something(with_some_params)).to.throw_exactly(any_exception)
+    """
+
+    def matches(self):
+        return type(self.raised) == self.expected
+
+    @property
+    def verb(self):
+        return 'be exactly raised'
 
 
 expect.register('throw', ExceptionMatcher)
+expect.register('throw_exactly', ExactExceptionMatcher)

--- a/tests/integrations/test_exception.py
+++ b/tests/integrations/test_exception.py
@@ -18,3 +18,19 @@ class TestExceptionIntegrations(TestCase):
     @must_fail
     def test_not_exception_failure(self):
         expect(lambda: 1 / 0).not_to.throw(ZeroDivisionError)
+
+
+class TestExactExceptionIntegrations(TestCase):
+    def test_exact_exception_success(self):
+        expect(lambda: 1 / 0).to.throw_exactly(ZeroDivisionError)
+
+    @must_fail
+    def test_exact_exception_failure(self):
+        expect(lambda: 1 / 0).to.throw_exactly(Exception)
+
+    def test_not_exact_exception_success(self):
+        expect(lambda: 1 / 0).not_to.throw_exactly(Exception)
+
+    @must_fail
+    def test_not_exact_exception_failure(self):
+        expect(lambda: 1 / 0).not_to.throw_exactly(ZeroDivisionError)

--- a/tests/matchers/test_exception.py
+++ b/tests/matchers/test_exception.py
@@ -1,15 +1,20 @@
-import unittest
+from unittest import TestCase
 
 from robber import expect
-from robber.matchers.exception import ExceptionMatcher
+from robber.matchers.exception import ExceptionMatcher, ExactExceptionMatcher
 
 
-class TestExceptionMatcher(unittest.TestCase):
+class TestExceptionMatcher(TestCase):
     def raise_exception(self, ex):
         raise ex
 
+    def test_verb(self):
+        exception = ExceptionMatcher(lambda: 1 / 1)
+        expect(exception.verb).to.eq('be raised')
+
     def test_matches(self):
         expect(ExceptionMatcher(lambda: 1 / 0, ZeroDivisionError).matches()).to.eq(True)
+        expect(ExceptionMatcher(lambda: 1 / 0, Exception).matches()).to.eq(True)
         expect(ExceptionMatcher(lambda: None, Exception).matches()).to.eq(False)
 
     def test_actual_is_not_callable(self):
@@ -44,3 +49,52 @@ Z = 'nothing'
 Expected A to be raised
 Actually raised Z
 """
+
+    def test_register(self):
+        expect(expect.matcher('throw')) == ExceptionMatcher
+
+
+class TestExactExceptionMatcher(TestCase):
+    def raise_exception(self, ex):
+        raise ex
+
+    def test_verb(self):
+        exception = ExactExceptionMatcher(lambda: 1 + 1)
+        expect(exception.verb).to.eq('be exactly raised')
+
+    def test_matches(self):
+        expect(ExactExceptionMatcher(lambda: 1 / 0, ZeroDivisionError).matches()).to.eq(True)
+        expect(ExactExceptionMatcher(lambda: 1 / 0, Exception).matches()).to.eq(False)
+
+    def test_explanation_message_with_wrong_exception(self):
+        exception_raised = ExactExceptionMatcher(lambda: self.raise_exception(TypeError()), ZeroDivisionError)
+        message = exception_raised.explanation.message
+        expect(message) == """
+A = 'ZeroDivisionError'
+Z = 'TypeError'
+Expected A to be exactly raised
+Actually exactly raised Z
+"""
+
+    def test_negative_explanation_message_with_wrong_exception(self):
+        exception_raised = ExactExceptionMatcher(
+            lambda: self.raise_exception(ZeroDivisionError()), ZeroDivisionError, is_negative=True)
+        message = exception_raised.explanation.message
+        expect(message) == """
+A = 'ZeroDivisionError'
+Expected A not to be exactly raised
+But it happened
+"""
+
+    def test_explanation_message_with_no_exception_was_raised(self):
+        no_exception = ExactExceptionMatcher(lambda: None, Exception)
+        message = no_exception.explanation.message
+        expect(message) == """
+A = 'Exception'
+Z = 'nothing'
+Expected A to be exactly raised
+Actually exactly raised Z
+"""
+
+    def test_register(self):
+        expect(expect.matcher('throw_exactly')) == ExactExceptionMatcher


### PR DESCRIPTION
### Related issue
https://github.com/EastAgile/robber.py/issues/9

### Description
Let's add this expectation to our code base:

```python
expect(lambda).to.throw_exactly(Exception)
```
This asserts that the target throws exactly an exception (not its subclass)

### Usage
This passed:
```python
expect(lambda: 1 / 0).to.throw_exactly(ZeroDivisionError)
```

This failed:
```python
expect(lambda: 1 / 0).to.throw_exactly(Exception)
```

