### PR TITLE
[f] Unicode comparison

### DIFF
--- a/robber/helper.py
+++ b/robber/helper.py
@@ -1,66 +1,64 @@
 import re
 
 
-class Helper:
-    @staticmethod
-    def build_expected_params_string(expected, args, kwargs):
-        if not expected:
-            return 'no arguments'
+def build_expected_params_string(expected, args, kwargs):
+    if not expected:
+        return 'no arguments'
 
-        expected_params_str = str(expected)
-        if args:
-            # Remove the parenthesis
-            match = re.search('\((.*)\)', str(args))
-            args_str = match.group(1)
-            expected_params_str = ', '.join((expected_params_str, args_str))
+    expected_params_str = str(expected)
+    if args:
+        # Remove the parenthesis
+        match = re.search('\((.*)\)', str(args))
+        args_str = match.group(1)
+        expected_params_str = ', '.join((expected_params_str, args_str))
 
-        if kwargs:
-            # Convert {'a':  1, 'b': 2} to 'a=1, b=2'
-            kwargs_str = ', '.join(['{0}={1!r}'.format(k, v) for k, v in kwargs.items()])
-            expected_params_str = ', '.join((expected_params_str, kwargs_str))
+    if kwargs:
+        # Convert {'a':  1, 'b': 2} to 'a=1, b=2'
+        kwargs_str = ', '.join(['{0}={1!r}'.format(k, v) for k, v in kwargs.items()])
+        expected_params_str = ', '.join((expected_params_str, kwargs_str))
 
-        return expected_params_str
+    return expected_params_str
 
-    @staticmethod
-    def build_called_params_string(call_args):
-        match = re.search('call\((.*)\)', str(call_args))
-        params = match.group(1)
-        return params or 'no arguments'
 
-    @classmethod
-    def unicode_to_str(cls, obj):
-        try:
-            if type(obj) is unicode:
-                return cls.unicode_string_to_str(obj)
-        except NameError:
-            pass
+def build_called_params_string(call_args):
+    match = re.search('call\((.*)\)', str(call_args))
+    params = match.group(1)
+    return params or 'no arguments'
 
-        if type(obj) is list:
-            return cls.unicode_list_to_str_list(obj)
 
-        if type(obj) is dict:
-            return cls.unicode_dict_to_str_dict(obj)
+def unicode_to_str(obj):
+    try:
+        if type(obj) is unicode:
+            return _unicode_string_to_str(obj)
+    except NameError:
+        pass
 
-        return obj
+    if type(obj) is list:
+        return _unicode_list_to_str_list(obj)
 
-    @staticmethod
-    def unicode_string_to_str(u_string):
-        return u_string.encode('utf-8')
+    if type(obj) is dict:
+        return _unicode_dict_to_str_dict(obj)
 
-    @classmethod
-    def unicode_list_to_str_list(cls, u_list):
-        str_list = list(u_list)
+    return obj
 
-        for i in range(0, len(str_list)):
-            str_list[i] = cls.unicode_to_str(str_list[i])
 
-        return str_list
+def _unicode_string_to_str(u_string):
+    return u_string.encode('utf-8')
 
-    @classmethod
-    def unicode_dict_to_str_dict(cls, u_dict):
-        str_dict = dict(u_dict)
 
-        for key in str_dict:
-            str_dict[key] = cls.unicode_to_str(str_dict[key])
+def _unicode_list_to_str_list(u_list):
+    str_list = list(u_list)
 
-        return str_dict
+    for i in range(0, len(str_list)):
+        str_list[i] = unicode_to_str(str_list[i])
+
+    return str_list
+
+
+def _unicode_dict_to_str_dict(u_dict):
+    str_dict = dict(u_dict)
+
+    for key in str_dict:
+        str_dict[key] = unicode_to_str(str_dict[key])
+
+    return str_dict

--- a/robber/helper.py
+++ b/robber/helper.py
@@ -28,18 +28,23 @@ class Helper:
         return params or 'no arguments'
 
     @classmethod
-    def is_str_or_unicode(cls, obj):
-        return type(obj) is str or cls.is_unicode(obj)
-
-    @staticmethod
-    def is_unicode(obj):
+    def unicode_to_str(cls, obj):
         try:
-            return type(obj) is unicode
+            if type(obj) is unicode:
+                return cls.unicode_string_to_str(obj)
         except NameError:
-            return False
+            pass
+
+        if type(obj) is list:
+            return cls.unicode_list_to_str_list(obj)
+
+        if type(obj) is dict:
+            return cls.unicode_dict_to_str_dict(obj)
+
+        return obj
 
     @staticmethod
-    def unicode_to_str(u_string):
+    def unicode_string_to_str(u_string):
         return u_string.encode('utf-8')
 
     @classmethod
@@ -47,10 +52,7 @@ class Helper:
         str_list = list(u_list)
 
         for i in range(0, len(str_list)):
-            if cls.is_unicode(str_list[i]):
-                str_list[i] = cls.unicode_to_str(str_list[i])
-            elif type(str_list[i]) is list:
-                str_list[i] = cls.unicode_list_to_str_list(str_list[i])
+            str_list[i] = cls.unicode_to_str(str_list[i])
 
         return str_list
 
@@ -59,9 +61,6 @@ class Helper:
         str_dict = dict(u_dict)
 
         for key in str_dict:
-            if cls.is_unicode(str_dict[key]):
-                str_dict[key] = cls.unicode_to_str(str_dict[key])
-            elif type(str_dict[key]) is dict:
-                str_dict[key] = cls.unicode_dict_to_str_dict(str_dict[key])
+            str_dict[key] = cls.unicode_to_str(str_dict[key])
 
         return str_dict

--- a/robber/helper.py
+++ b/robber/helper.py
@@ -26,3 +26,18 @@ class Helper:
         match = re.search('call\((.*)\)', str(call_args))
         params = match.group(1)
         return params or 'no arguments'
+
+    @classmethod
+    def is_str_or_unicode(cls, obj):
+        return type(obj) is str or cls.is_unicode(obj)
+
+    @staticmethod
+    def is_unicode(obj):
+        try:
+            return type(obj) is unicode
+        except NameError:
+            return False
+
+    @staticmethod
+    def unicode_to_str(u_string):
+        return u_string.encode('utf-8')

--- a/robber/helper.py
+++ b/robber/helper.py
@@ -53,3 +53,15 @@ class Helper:
                 str_list[i] = cls.unicode_list_to_str_list(str_list[i])
 
         return str_list
+
+    @classmethod
+    def unicode_dict_to_str_dict(cls, u_dict):
+        str_dict = dict(u_dict)
+
+        for key in str_dict:
+            if cls.is_unicode(str_dict[key]):
+                str_dict[key] = cls.unicode_to_str(str_dict[key])
+            elif type(str_dict[key]) is dict:
+                str_dict[key] = cls.unicode_dict_to_str_dict(str_dict[key])
+
+        return str_dict

--- a/robber/helper.py
+++ b/robber/helper.py
@@ -41,3 +41,15 @@ class Helper:
     @staticmethod
     def unicode_to_str(u_string):
         return u_string.encode('utf-8')
+
+    @classmethod
+    def unicode_list_to_str_list(cls, u_list):
+        str_list = list(u_list)
+
+        for i in range(0, len(str_list)):
+            if cls.is_unicode(str_list[i]):
+                str_list[i] = cls.unicode_to_str(str_list[i])
+            elif type(str_list[i]) is list:
+                str_list[i] = cls.unicode_list_to_str_list(str_list[i])
+
+        return str_list

--- a/robber/matchers/called_once_with.py
+++ b/robber/matchers/called_once_with.py
@@ -2,7 +2,7 @@ from mock import call
 
 from robber import expect
 from robber.explanation import Explanation
-from robber.helper import Helper
+from robber.helper import build_expected_params_string, build_called_params_string
 from robber.matchers.base import Base
 
 
@@ -21,7 +21,7 @@ class CalledOnceWith(Base):
 
     @property
     def explanation(self):
-        expected_args = Helper.build_expected_params_string(
+        expected_args = build_expected_params_string(
             expected=self.expected, args=self.args, kwargs=self.kwargs
         )
 
@@ -31,7 +31,7 @@ class CalledOnceWith(Base):
                 more_detail='Actually not called', force_disable_repr=True
             )
 
-        called_args = Helper.build_called_params_string(self.actual.call_args)
+        called_args = build_called_params_string(self.actual.call_args)
         additional_info = 'Actually called {call_count} times with Z'.format(call_count=self.actual.call_count)
 
         return Explanation(

--- a/robber/matchers/called_with.py
+++ b/robber/matchers/called_with.py
@@ -2,7 +2,7 @@ from mock import call
 
 from robber import expect
 from robber.explanation import Explanation
-from robber.helper import Helper
+from robber.helper import build_expected_params_string, build_called_params_string
 from robber.matchers.base import Base
 
 
@@ -19,7 +19,7 @@ class CalledWith(Base):
 
     @property
     def explanation(self):
-        expected_args = Helper.build_expected_params_string(
+        expected_args = build_expected_params_string(
             expected=self.expected, args=self.args, kwargs=self.kwargs
         )
 
@@ -29,7 +29,7 @@ class CalledWith(Base):
                 more_detail='Actually not called', force_disable_repr=True
             )
 
-        called_params = Helper.build_called_params_string(self.actual.call_args)
+        called_params = build_called_params_string(self.actual.call_args)
         return Explanation(
             self.actual, self.is_negative, 'be called with', expected_args,
             other=called_params, force_disable_repr=True

--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -15,15 +15,7 @@ class Equal(Base):
     """
 
     def matches(self):
-        if Helper.is_str_or_unicode(self.actual) and Helper.is_str_or_unicode(self.expected):
-            try:
-                if type(self.actual) is unicode:
-                    self.actual = Helper.unicode_to_str(self.actual)
-                if type(self.expected) is unicode:
-                    self.expected = Helper.unicode_to_str(self.expected)
-            except NameError:
-                pass
-
+        self.standardize_args()
         return self.actual == self.expected
 
     @property
@@ -70,6 +62,21 @@ class Equal(Base):
         differ = Differ()
         diffs = differ.compare(self.actual.splitlines(), self.expected.splitlines())
         return 'Diffs:\n{0}'.format('\n'.join(diffs))
+
+    def standardize_args(self):
+        try:
+            if type(self.actual) is unicode:
+                self.actual = Helper.unicode_to_str(self.actual)
+            if type(self.expected) is unicode:
+                self.expected = Helper.unicode_to_str(self.expected)
+        except NameError:
+            pass
+
+        if type(self.actual) is list:
+            self.actual = Helper.unicode_list_to_str_list(self.actual)
+
+        if type(self.expected) is list:
+            self.expected = Helper.unicode_list_to_str_list(self.expected)
 
 
 expect.register('eq', Equal)

--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -2,6 +2,7 @@ from difflib import Differ
 
 from robber import expect
 from robber.explanation import Explanation
+from robber.helper import Helper
 from robber.matchers.base import Base
 
 
@@ -14,6 +15,15 @@ class Equal(Base):
     """
 
     def matches(self):
+        if Helper.is_str_or_unicode(self.actual) and Helper.is_str_or_unicode(self.expected):
+            try:
+                if type(self.actual) is unicode:
+                    self.actual = Helper.unicode_to_str(self.actual)
+                if type(self.expected) is unicode:
+                    self.expected = Helper.unicode_to_str(self.expected)
+            except NameError:
+                pass
+
         return self.actual == self.expected
 
     @property

--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -2,7 +2,7 @@ from difflib import Differ
 
 from robber import expect
 from robber.explanation import Explanation
-from robber.helper import Helper
+from robber.helper import unicode_to_str
 from robber.matchers.base import Base
 
 
@@ -64,8 +64,8 @@ class Equal(Base):
         return 'Diffs:\n{0}'.format('\n'.join(diffs))
 
     def standardize_args(self):
-        self.actual = Helper.unicode_to_str(self.actual)
-        self.expected = Helper.unicode_to_str(self.expected)
+        self.actual = unicode_to_str(self.actual)
+        self.expected = unicode_to_str(self.expected)
 
 
 expect.register('eq', Equal)

--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -78,6 +78,12 @@ class Equal(Base):
         if type(self.expected) is list:
             self.expected = Helper.unicode_list_to_str_list(self.expected)
 
+        if type(self.actual) is dict:
+            self.actual = Helper.unicode_dict_to_str_dict(self.actual)
+
+        if type(self.expected) is dict:
+            self.expected = Helper.unicode_dict_to_str_dict(self.expected)
+
 
 expect.register('eq', Equal)
 expect.register('__eq__', Equal)

--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -64,25 +64,8 @@ class Equal(Base):
         return 'Diffs:\n{0}'.format('\n'.join(diffs))
 
     def standardize_args(self):
-        try:
-            if type(self.actual) is unicode:
-                self.actual = Helper.unicode_to_str(self.actual)
-            if type(self.expected) is unicode:
-                self.expected = Helper.unicode_to_str(self.expected)
-        except NameError:
-            pass
-
-        if type(self.actual) is list:
-            self.actual = Helper.unicode_list_to_str_list(self.actual)
-
-        if type(self.expected) is list:
-            self.expected = Helper.unicode_list_to_str_list(self.expected)
-
-        if type(self.actual) is dict:
-            self.actual = Helper.unicode_dict_to_str_dict(self.actual)
-
-        if type(self.expected) is dict:
-            self.expected = Helper.unicode_dict_to_str_dict(self.expected)
+        self.actual = Helper.unicode_to_str(self.actual)
+        self.expected = Helper.unicode_to_str(self.expected)
 
 
 expect.register('eq', Equal)

--- a/robber/matchers/ever_called_with.py
+++ b/robber/matchers/ever_called_with.py
@@ -2,7 +2,7 @@ from mock import call
 
 from robber import expect
 from robber.explanation import Explanation
-from robber.helper import Helper
+from robber.helper import build_expected_params_string
 from robber.matchers.base import Base
 
 
@@ -20,7 +20,7 @@ class EverCalledWith(Base):
 
     @property
     def explanation(self):
-        expected_args = Helper.build_expected_params_string(
+        expected_args = build_expected_params_string(
             expected=self.expected, args=self.args, kwargs=self.kwargs
         )
         return Explanation(

--- a/tests/integrations/test_equal.py
+++ b/tests/integrations/test_equal.py
@@ -13,9 +13,13 @@ class TestEqualIntegrations(TestCase):
         expect((1, 2)).to.eq((1, 2))
         expect(1).to == 1
         expect(1) == 1
+        # unicode string
         expect(u'Mèo').to.eq('Mèo')
+        # unicode list
         expect([u'Mèo', u'Chó']).to.eq(['Mèo', 'Chó'])
+        # unicode list in list
         expect([[u'Mèo'], [u'Chó']]).to.eq([['Mèo'], ['Chó']])
+        # unicode dict
         expect({
             'cat': u'Mèo',
             'dog': u'Chó',
@@ -23,6 +27,7 @@ class TestEqualIntegrations(TestCase):
             'cat': 'Mèo',
             'dog': 'Chó',
         })
+        # unicode dict in dict
         expect({
             'd1': {'cat': u'Mèo'},
             'd2': {'dog': u'Chó'},
@@ -30,6 +35,20 @@ class TestEqualIntegrations(TestCase):
             'd1': {'cat': 'Mèo'},
             'd2': {'dog': 'Chó'},
         })
+        # unicode list in dict
+        expect({
+            'd1': [u'Mèo', u'Chó'],
+            'd2': [u'Mèo', u'Chó'],
+        }).to.eq({
+            'd1': ['Mèo', 'Chó'],
+            'd2': ['Mèo', 'Chó'],
+        })
+        # unicode dict in list
+        expect(
+            [{'cat': u'Mèo', 'dog': u'Chó'}, {'cat': u'Mèo', 'dog': u'Chó'}]
+        ).to.eq(
+            [{'cat': 'Mèo', 'dog': 'Chó'}, {'cat': 'Mèo', 'dog': 'Chó'}]
+        )
 
     @must_fail
     def test_eq_failure(self):

--- a/tests/integrations/test_equal.py
+++ b/tests/integrations/test_equal.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from unittest import TestCase
 
 from robber import expect
@@ -11,6 +13,7 @@ class TestEqualIntegrations(TestCase):
         expect((1, 2)).to.eq((1, 2))
         expect(1).to == 1
         expect(1) == 1
+        expect(u'Mèo').to.eq('Mèo')
 
     @must_fail
     def test_eq_failure(self):

--- a/tests/integrations/test_equal.py
+++ b/tests/integrations/test_equal.py
@@ -16,6 +16,20 @@ class TestEqualIntegrations(TestCase):
         expect(u'Mèo').to.eq('Mèo')
         expect([u'Mèo', u'Chó']).to.eq(['Mèo', 'Chó'])
         expect([[u'Mèo'], [u'Chó']]).to.eq([['Mèo'], ['Chó']])
+        expect({
+            'cat': u'Mèo',
+            'dog': u'Chó',
+        }).to.eq({
+            'cat': 'Mèo',
+            'dog': 'Chó',
+        })
+        expect({
+            'd1': {'cat': u'Mèo'},
+            'd2': {'dog': u'Chó'},
+        }).to.eq({
+            'd1': {'cat': 'Mèo'},
+            'd2': {'dog': 'Chó'},
+        })
 
     @must_fail
     def test_eq_failure(self):

--- a/tests/integrations/test_equal.py
+++ b/tests/integrations/test_equal.py
@@ -14,6 +14,8 @@ class TestEqualIntegrations(TestCase):
         expect(1).to == 1
         expect(1) == 1
         expect(u'Mèo').to.eq('Mèo')
+        expect([u'Mèo', u'Chó']).to.eq(['Mèo', 'Chó'])
+        expect([[u'Mèo'], [u'Chó']]).to.eq([['Mèo'], ['Chó']])
 
     @must_fail
     def test_eq_failure(self):

--- a/tests/matchers/test_equal.py
+++ b/tests/matchers/test_equal.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from unittest import TestCase
 
 from mock import patch
@@ -11,6 +13,12 @@ class TestEqual:
     def test_matches(self):
         expect(Equal(1, 1).matches()).to.eq(True)
         expect(Equal(1, 2).matches()).to.eq(False)
+
+    def test_if_unicode_string_is_converted_to_str(self):
+        equal = Equal(u'Mèo', u'Mèo')
+        equal.matches()
+        expect(type(equal.actual)).to.equal(str)
+        expect(type(equal.expected)).to.equal(str)
 
     def test_register(self):
         expect(expect.matcher('eq')) == Equal

--- a/tests/matchers/test_equal.py
+++ b/tests/matchers/test_equal.py
@@ -130,3 +130,17 @@ class TestStandardizeArgs(TestCase):
         equal.matches()
         self.assertEqual(equal.actual, ['Mèo', 'Chó'])
         self.assertEqual(equal.expected, ['Mèo', 'Chó'])
+
+    def test_if_unicode_dict_is_converted_to_str_dict(self):
+        u_dict = {
+            'cat': u'Mèo',
+            'dog': u'Chó',
+        }
+        str_dict = {
+            'cat': 'Mèo',
+            'dog': 'Chó',
+        }
+        equal = Equal(u_dict, u_dict)
+        equal.matches()
+        self.assertEqual(equal.actual, str_dict)
+        self.assertEqual(equal.expected, str_dict)

--- a/tests/matchers/test_equal.py
+++ b/tests/matchers/test_equal.py
@@ -14,12 +14,6 @@ class TestEqual:
         expect(Equal(1, 1).matches()).to.eq(True)
         expect(Equal(1, 2).matches()).to.eq(False)
 
-    def test_if_unicode_string_is_converted_to_str(self):
-        equal = Equal(u'Mèo', u'Mèo')
-        equal.matches()
-        expect(type(equal.actual)).to.equal(str)
-        expect(type(equal.expected)).to.equal(str)
-
     def test_register(self):
         expect(expect.matcher('eq')) == Equal
         expect(expect.matcher('__eq__')) == Equal
@@ -122,3 +116,17 @@ Expected A not to equal B
         equal = Equal(l1, l2)
 
         expect('Some diffs' in equal.explanation.message).to.eq(True)
+
+
+class TestStandardizeArgs(TestCase):
+    def test_if_unicode_string_is_converted_to_str(self):
+        equal = Equal(u'Mèo', u'Mèo')
+        equal.matches()
+        self.assertEqual(equal.actual, 'Mèo')
+        self.assertEqual(equal.expected, 'Mèo')
+
+    def test_if_unicode_list_is_converted_to_str_list(self):
+        equal = Equal([u'Mèo', u'Chó'], [u'Mèo', u'Chó'])
+        equal.matches()
+        self.assertEqual(equal.actual, ['Mèo', 'Chó'])
+        self.assertEqual(equal.expected, ['Mèo', 'Chó'])

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+import sys
 from unittest import TestCase
 
 from mock import call
@@ -57,3 +60,33 @@ class TestBuildExpectedParamsString(TestCase):
         expect(split_expected_params_str).to.contain("'a'")
         expect(split_expected_params_str).to.contain("b='b'")
         expect(split_expected_params_str).to.contain('one=1')
+
+
+class TestIsUnicode(TestCase):
+    def test_with_str(self):
+        expect(Helper.is_unicode('a')).to.eq(False)
+
+    def test_with_unicode(self):
+        if sys.version_info.major < 3:
+            expect(Helper.is_unicode(u'a')).to.eq(True)
+        else:
+            expect(Helper.is_unicode(u'a')).to.eq(False)
+
+    def test_with_int(self):
+        expect(Helper.is_unicode(1)).to.eq(False)
+
+
+class TestIsStrOrUnicode(TestCase):
+    def test_with_str(self):
+        expect(Helper.is_str_or_unicode('a')).to.eq(True)
+
+    def test_with_unicode(self):
+        expect(Helper.is_str_or_unicode(u'a')).to.eq(True)
+
+    def test_with_int(self):
+        expect(Helper.is_str_or_unicode(1)).to.eq(False)
+
+
+class TestUnicodeToStr(TestCase):
+    def test_unicode_to_str(self):
+        self.assertEqual(Helper.unicode_to_str(u'Mèo'), u'Mèo'.encode('utf-8'))

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -67,7 +67,8 @@ class TestIsUnicode(TestCase):
         expect(Helper.is_unicode('a')).to.eq(False)
 
     def test_with_unicode(self):
-        if sys.version_info.major < 3:
+        # python <= 2.7
+        if type(sys.version_info) is tuple or sys.version_info.major < 3:
             expect(Helper.is_unicode(u'a')).to.eq(True)
         else:
             expect(Helper.is_unicode(u'a')).to.eq(False)
@@ -102,3 +103,27 @@ class TestUnicodeListToStrList(TestCase):
         u_list = [[u'Mèo'], [u'Chó']]
         str_list = [['Mèo'], ['Chó']]
         self.assertEqual(Helper.unicode_list_to_str_list(u_list), str_list)
+
+
+class TestUnicodeDictToStrDict(TestCase):
+    def test_with_simple_dict(self):
+        u_dict = {
+            'cat': u'Mèo',
+            'dog': u'Chó',
+        }
+        str_dict = {
+            'cat': 'Mèo',
+            'dog': 'Chó',
+        }
+        self.assertEqual(Helper.unicode_dict_to_str_dict(u_dict), str_dict)
+
+    def test_with_multi_level_dict(self):
+        u_dict = {
+            'd1': {'cat': u'Mèo'},
+            'd2': {'dog': u'Chó'},
+        }
+        str_dict = {
+            'd1': {'cat': 'Mèo'},
+            'd2': {'dog': 'Chó'},
+        }
+        self.assertEqual(Helper.unicode_dict_to_str_dict(u_dict), str_dict)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -90,3 +90,15 @@ class TestIsStrOrUnicode(TestCase):
 class TestUnicodeToStr(TestCase):
     def test_unicode_to_str(self):
         self.assertEqual(Helper.unicode_to_str(u'Mèo'), u'Mèo'.encode('utf-8'))
+
+
+class TestUnicodeListToStrList(TestCase):
+    def test_with_simple_list(self):
+        u_list = [u'Mèo', u'Chó']
+        str_list = ['Mèo', 'Chó']
+        self.assertEqual(Helper.unicode_list_to_str_list(u_list), str_list)
+
+    def test_with_multi_level_list(self):
+        u_list = [[u'Mèo'], [u'Chó']]
+        str_list = [['Mèo'], ['Chó']]
+        self.assertEqual(Helper.unicode_list_to_str_list(u_list), str_list)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -5,38 +5,41 @@ from unittest import TestCase
 from mock import call, patch
 
 from robber.expect import expect
-from robber.helper import Helper
+from robber.helper import (
+    build_called_params_string, build_expected_params_string, _unicode_string_to_str, unicode_to_str,
+    _unicode_list_to_str_list, _unicode_dict_to_str_dict
+)
 
 
 class TestBuildCalledParamsString(TestCase):
     def test_with_no_params(self):
         call_args = call()
-        call_args_str = Helper.build_called_params_string(call_args)
+        call_args_str = build_called_params_string(call_args)
 
         expect(call_args_str).to.eq('no arguments')
 
     def test_with_args_and_kwargs(self):
         call_args = call(1, 'a', 3, a=1, b=2)
-        call_args_str = Helper.build_called_params_string(call_args)
+        call_args_str = build_called_params_string(call_args)
 
         expect(call_args_str).to.eq("1, 'a', 3, a=1, b=2")
 
 
 class TestBuildExpectedParamsString(TestCase):
     def test_with_no_params(self):
-        expected_params_str = Helper.build_expected_params_string(expected=None, args=None, kwargs=None)
+        expected_params_str = build_expected_params_string(expected=None, args=None, kwargs=None)
         expect(expected_params_str).to.eq('no arguments')
 
     def test_with_expected(self):
-        expected_params_str = Helper.build_expected_params_string(expected=1, args=None, kwargs=None)
+        expected_params_str = build_expected_params_string(expected=1, args=None, kwargs=None)
         expect(expected_params_str).to.eq('1')
 
     def test_with_expected_and_args(self):
-        expected_params_str = Helper.build_expected_params_string(expected=1, args=(2, 'a'), kwargs=None)
+        expected_params_str = build_expected_params_string(expected=1, args=(2, 'a'), kwargs=None)
         expect(expected_params_str).to.eq("1, 2, 'a'")
 
     def test_with_expected_and_kwargs(self):
-        expected_params_str = Helper.build_expected_params_string(
+        expected_params_str = build_expected_params_string(
             expected=1, args=None, kwargs={'a': 'a', 'one': 1}
         )
         # Since we cannot be sure about the order of a dict, which leads to the situation that the function
@@ -49,7 +52,7 @@ class TestBuildExpectedParamsString(TestCase):
         expect(split_expected_params_str).to.contain('one=1')
 
     def test_with_expected_and_args_and_kwargs(self):
-        expected_params_str = Helper.build_expected_params_string(
+        expected_params_str = build_expected_params_string(
             expected=1, args=(2, 'a'), kwargs={'b': 'b', 'one': 1}
         )
         split_expected_params_str = expected_params_str.split(', ')
@@ -63,49 +66,49 @@ class TestBuildExpectedParamsString(TestCase):
 
 class TestUnicodeStringToStr(TestCase):
     def test_unicode_string_to_str(self):
-        self.assertEqual(Helper.unicode_string_to_str(u'Mèo'), u'Mèo'.encode('utf-8'))
+        self.assertEqual(_unicode_string_to_str(u'Mèo'), u'Mèo'.encode('utf-8'))
 
 
 class TestUnicodeListToStrList(TestCase):
-    @patch('tests.test_helper.Helper.unicode_to_str')
+    @patch('robber.helper.unicode_to_str')
     def test_unicode_list_to_str_list(self, mock_unicode_to_str):
-        Helper.unicode_list_to_str_list([u'Mèo', u'Chó'])
+        _unicode_list_to_str_list([u'Mèo', u'Chó'])
         mock_unicode_to_str.assert_any_call(u'Mèo')
         mock_unicode_to_str.assert_any_call(u'Chó')
 
 
 class TestUnicodeDictToStrDict(TestCase):
-    @patch('tests.test_helper.Helper.unicode_to_str')
+    @patch('robber.helper.unicode_to_str')
     def test_unicode_dict_to_str_dict(self, mock_unicode_to_str):
         u_dict = {
             'cat': u'Mèo',
             'dog': u'Chó',
         }
-        Helper.unicode_dict_to_str_dict(u_dict)
+        _unicode_dict_to_str_dict(u_dict)
         mock_unicode_to_str.assert_any_call(u'Mèo')
         mock_unicode_to_str.assert_any_call(u'Chó')
 
 
 class TestUnicodeToStr(TestCase):
-    @patch('tests.test_helper.Helper.unicode_string_to_str')
+    @patch('robber.helper._unicode_string_to_str')
     def test_with_unicode_string(self, mock_unicode_string_to_str):
-        Helper.unicode_to_str(u'Mèo')
+        unicode_to_str(u'Mèo')
         # python <= 2.7
         if sys.version_info[0] < 3:
             mock_unicode_string_to_str.assert_called_with(u'Mèo')
         else:
             mock_unicode_string_to_str.assert_not_called()
 
-    @patch('tests.test_helper.Helper.unicode_list_to_str_list')
+    @patch('robber.helper._unicode_list_to_str_list')
     def test_with_unicode_list(self, mock_unicode_list_to_str_list):
-        Helper.unicode_to_str([u'Mèo', u'Chó'])
+        unicode_to_str([u'Mèo', u'Chó'])
         mock_unicode_list_to_str_list.assert_called_with([u'Mèo', u'Chó'])
 
-    @patch('tests.test_helper.Helper.unicode_dict_to_str_dict')
+    @patch('robber.helper._unicode_dict_to_str_dict')
     def test_with_unicode_dict(self, mock_unicode_dict_to_str_dict):
         u_dict = {
             'cat': u'Mèo',
             'dog': u'Chó',
         }
-        Helper.unicode_to_str(u_dict)
+        unicode_to_str(u_dict)
         mock_unicode_dict_to_str_dict.assert_called_with(u_dict)


### PR DESCRIPTION
### Related issue
https://github.com/EastAgile/robber.py/issues/12

### Description
Now users can use compare a normal string to a unicode string. We also support comparing multi-level dicts and lists that contain unicode strings.

### Usage
```python
# unicode string
expect(u'Mèo').to.eq('Mèo')
# unicode list
expect([u'Mèo', u'Chó']).to.eq(['Mèo', 'Chó'])
# unicode list in list
expect([[u'Mèo'], [u'Chó']]).to.eq([['Mèo'], ['Chó']])
# unicode dict
expect({
    'cat': u'Mèo',
    'dog': u'Chó',
}).to.eq({
    'cat': 'Mèo',
    'dog': 'Chó',
})
# unicode dict in dict
expect({
    'd1': {'cat': u'Mèo'},
    'd2': {'dog': u'Chó'},
}).to.eq({
    'd1': {'cat': 'Mèo'},
    'd2': {'dog': 'Chó'},
})
# unicode list in dict
expect({
    'd1': [u'Mèo', u'Chó'],
    'd2': [u'Mèo', u'Chó'],
}).to.eq({
    'd1': ['Mèo', 'Chó'],
    'd2': ['Mèo', 'Chó'],
})
# unicode dict in list
expect(
    [{'cat': u'Mèo', 'dog': u'Chó'}, {'cat': u'Mèo', 'dog': u'Chó'}]
).to.eq(
    [{'cat': 'Mèo', 'dog': 'Chó'}, {'cat': 'Mèo', 'dog': 'Chó'}]
)
```