### PR TITLE
[r] Better must_fail 

### DIFF
--- a/robber/bad_expectation.py
+++ b/robber/bad_expectation.py
@@ -1,3 +1,6 @@
+from termcolor import colored
+
+
 class BadExpectation(Exception):
     """
     Raised when an assertion fails.
@@ -8,4 +11,4 @@ class BadExpectation(Exception):
         self.message = message
 
     def __str__(self):
-        return self.message
+        return colored(self.message, 'red')

--- a/robber/matchers/base.py
+++ b/robber/matchers/base.py
@@ -29,6 +29,7 @@ class Base:
             return expect(self.actual)
 
         message = self.message or self.explanation.message
+        # raise BadExpectation(colored(message, 'red'))
         raise BadExpectation(colored(message, 'red'))
 
     @property

--- a/robber/matchers/base.py
+++ b/robber/matchers/base.py
@@ -29,8 +29,7 @@ class Base:
             return expect(self.actual)
 
         message = self.message or self.explanation.message
-        # raise BadExpectation(colored(message, 'red'))
-        raise BadExpectation(colored(message, 'red'))
+        raise BadExpectation(message)
 
     @property
     def negative_message(self):

--- a/robber/matchers/base.py
+++ b/robber/matchers/base.py
@@ -1,5 +1,3 @@
-from termcolor import colored
-
 from robber.bad_expectation import BadExpectation
 from robber.expect import expect
 

--- a/tests/integrations/test_numbers.py
+++ b/tests/integrations/test_numbers.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from robber.bad_expectation import BadExpectation
+
 from robber import expect
 from tests import must_fail
 
@@ -56,13 +58,22 @@ class TestChangeIntegrations(TestCase):
     def test_change_by_success(self):
         expect(lambda x: x + 1).to.change(0).by(1)
 
-    @must_fail
+    # New must_fail does not work with custom chains like this, we have to wrap it manually
     def test_change_by_failure(self):
-        expect(lambda x: x + 1).to.change(0).by(2)
+        try:
+            expect(lambda x: x + 1).to.change(0).by(2)
+        except BadExpectation:
+            pass
+        else:
+            raise BadExpectation('it must fail')
 
     def test_not_change_by_success(self):
         expect(lambda x: x + 1).not_to.change(0).by(2)
 
-    @must_fail
     def test_not_change_by_failure(self):
-        expect(lambda x: x + 1).not_to.change(0).by(1)
+        try:
+            expect(lambda x: x + 1).not_to.change(0).by(1)
+        except BadExpectation:
+            pass
+        else:
+            raise BadExpectation('it must fail')

--- a/tests/integrations/test_numbers.py
+++ b/tests/integrations/test_numbers.py
@@ -55,6 +55,7 @@ class TestWithinIntegrations(TestCase):
 
 
 class TestChangeIntegrations(TestCase):
+    @must_fail
     def test_change_by_success(self):
         expect(lambda x: x + 1).to.change(0).by(1)
 

--- a/tests/matchers/test_base.py
+++ b/tests/matchers/test_base.py
@@ -25,7 +25,7 @@ class TestBase(unittest.TestCase):
         try:
             matcher.match()
         except BadExpectation as failure:
-            expect(failure.message).to.eq(colored('Failure message', 'red'))
+            expect(failure.message).to.eq('Failure message')
         else:
             raise BadExpectation('it should raise an exception')
 

--- a/tests/matchers/test_base.py
+++ b/tests/matchers/test_base.py
@@ -1,7 +1,5 @@
 import unittest
 
-from termcolor import colored
-
 from robber import expect, BadExpectation
 from robber.matchers.base import Base
 from tests.fixtures import TestWillMatch, TestWontMatch

--- a/tests/test_bad_expectation.py
+++ b/tests/test_bad_expectation.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from termcolor import colored
+
 from robber import expect
 from robber.bad_expectation import BadExpectation
 
@@ -10,4 +12,4 @@ class TestBadExpectation(TestCase):
         # So this simple test is enough.
         message = 'You did something wrong!'
         bad_expectation = BadExpectation(message)
-        expect(str(bad_expectation)).to.eq(message)
+        expect(str(bad_expectation)).to.eq(colored(message, 'red'))

--- a/tests/test_custom_explanation.py
+++ b/tests/test_custom_explanation.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
 
-from termcolor import colored
-
 from robber import expect, BadExpectation, CustomExplanation
 
 

--- a/tests/test_custom_explanation.py
+++ b/tests/test_custom_explanation.py
@@ -11,6 +11,6 @@ class TestCustomExplanation(TestCase):
             with CustomExplanation('Something went wrong'):
                 expect(1).to.eq(2)
         except BadExpectation as e:
-            expect(e.message) == colored('Something went wrong', 'red')
+            expect(e.message) == 'Something went wrong'
         else:
-            raise BadExpectation(colored('must fail with custom message', 'red'))
+            raise BadExpectation('must fail with custom message')

--- a/tests/util.py
+++ b/tests/util.py
@@ -28,6 +28,9 @@ def reset():
 
 
 def must_fail(fn):
+    """
+    This checks if every expectation in a test fails.
+    """
     def test_decorated(self, *args, **kwargs):
         Base.match = new_match
         fn(self, *args, **kwargs)

--- a/tests/util.py
+++ b/tests/util.py
@@ -31,6 +31,7 @@ def must_fail(fn):
     """
     This checks if every expectation in a test fails.
     """
+
     def test_decorated(self, *args, **kwargs):
         Base.match = new_match
         fn(self, *args, **kwargs)
@@ -43,5 +44,7 @@ def must_fail(fn):
             raise BadExpectation(message)
 
         reset()
+
+    test_decorated.__name__ = fn.__name__
 
     return test_decorated

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,13 +1,44 @@
 from robber import BadExpectation
+from robber.matchers.base import Base
+
+expectation_count = 0
+fail_count = 0
+
+old_match = Base.match
 
 
-def must_fail(fn, *args, **kwargs):
+def new_match(self):
+    global expectation_count
+    expectation_count += 1
+
+    try:
+        old_match(self)
+    except BadExpectation:
+        global fail_count
+        fail_count += 1
+
+
+def reset():
+    global expectation_count
+    global fail_count
+
+    Base.match = old_match
+    expectation_count = 0
+    fail_count = 0
+
+
+def must_fail(fn):
     def test_decorated(self, *args, **kwargs):
-        try:
-            fn(self, *args, **kwargs)
-        except BadExpectation:
-            pass
-        else:
-            raise BadExpectation('it must fail')
+        Base.match = new_match
+        fn(self, *args, **kwargs)
+        message = 'The test has {expectation_count} expectations, only {fail_count} fails.'.format(
+            expectation_count=expectation_count, fail_count=fail_count
+        )
+
+        if fail_count < expectation_count:
+            reset()
+            raise BadExpectation(message)
+
+        reset()
 
     return test_decorated


### PR DESCRIPTION
### Related issue
https://github.com/EastAgile/robber.py/issues/53

### Description
Now, a `must_fail` test only passes if all of the expectations inside of it pass

### Usage

This fails:

```python
@must_fail
def test_eq_failure(self):
    expect(1).to.eq(2)
    expect(1).to.eq(1)
```

This passes:
```python
@must_fail
def test_eq_failure(self):
    expect(1).to.eq(2)
    expect(1).to.eq(3)
```

### Other changes

- Make BadExpectation handles the failure messages' color
- A must_fail test can be run alone and directly with `nose`.