### PR TITLE
[r] Disable the lengthy tracebacks

### DIFF
--- a/robber/__init__.py
+++ b/robber/__init__.py
@@ -1,7 +1,27 @@
-__all__ = [
-    'custom_explanation', 'expect', 'bad_expectations', 'matchers',
-]
+import sys
+
+# Do not change the importing order in the next 4 lines. Doing so may break everything.
 from robber.custom_explanation import CustomExplanation  # noqa F401
 from robber.expect import expect  # noqa F401
 from robber.bad_expectation import BadExpectation  # noqa F401
 import robber.matchers  # noqa F401
+
+__all__ = [
+    'custom_explanation', 'expect', 'bad_expectations', 'matchers',
+]
+
+# This hides the traceback
+sys.tracebacklimit = 0
+
+# This checks if ipython is installed then hide the traceback from it
+try:  # pragma: no cover
+    import traceback
+    from IPython.core.interactiveshell import InteractiveShell
+
+    def showtraceback(self):
+        traceback_lines = traceback.format_exception(*sys.exc_info())
+        sys.stderr.write(traceback_lines[-1])
+
+    InteractiveShell.showtraceback = showtraceback
+except ImportError:  # pragma: no cover
+    pass


### PR DESCRIPTION
### Related issue
https://github.com/EastAgile/robber.py/issues/42

### Description
The traceback is no longer there whenever an expectation fails. Now, only the failure message shows up. This also works with `ipython`.

### Usage

This fails:

```python
In: expect(1).to.be.eq(2)
Out: 
robber.bad_expectation.BadExpectation: 
A = 1
B = 2
Expected A to equal B

```