### PR TITLE
[b] Use `in` instead of fancy logic to make contain work properly

### DIFF
--- a/robber/__init__.py
+++ b/robber/__init__.py
@@ -18,7 +18,7 @@ try:  # pragma: no cover
     import traceback
     from IPython.core.interactiveshell import InteractiveShell
 
-    def showtraceback(self):
+    def showtraceback(self, running_compiled_code=False):
         traceback_lines = traceback.format_exception(*sys.exc_info())
         sys.stderr.write(traceback_lines[-1])
 

--- a/robber/matchers/contain.py
+++ b/robber/matchers/contain.py
@@ -12,26 +12,22 @@ class Contain(Base):
     def matches(self):
         expected_list = list(self.args)
         expected_list.insert(0, self.expected)
+        self.expected_arg = None
 
         if not self.is_negative:
-            # run when contain chain triggered
-            elements = set(expected_list).difference(self.actual)
+            for expected in expected_list:
+                if expected not in self.actual:
+                    self.expected_arg = expected
+                    break
 
         else:
-            # run when not contain/excluded chain triggered
-            elements = set(expected_list).intersection(self.actual)
+            for expected in expected_list:
+                if expected in self.actual:
+                    self.expected_arg = expected
+                    break
 
-        existed, self.expected_arg = self._get_first(elements)
+        existed = self.expected_arg is not None
         return existed is self.is_negative
-
-    @staticmethod
-    def _get_first(elements):
-        try:
-            first_element = elements.pop()
-        except KeyError:
-            return False, None
-        else:
-            return True, first_element
 
     @property
     def explanation(self):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if os.path.exists('README.rst'):
 
 setup(
     name='robber',
-    version='1.1.2',
+    version='1.1.3',
     description='BDD / TDD assertion library for Python',
     long_description=long_description,
     author='Tao Liang',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ import os
 
 from setuptools import setup
 
-long_description = 'BDD / TDD assertion library for Python',
+long_description = 'BDD / TDD assertion library for Python'
+
 if os.path.exists('README.rst'):
     long_description = open('README.rst').read()
 

--- a/tests/integrations/test_contain.py
+++ b/tests/integrations/test_contain.py
@@ -7,6 +7,10 @@ from tests import must_fail
 class TestContainIntegrations(TestCase):
     def test_contain_success(self):
         expect([1, 2, 3]).to.contain(2)
+        expect('abc').to.contain('abc')
+        expect('abc').to.contain('ab', 'bc')
+        expect([{"test": "test"}]).to.contain({"test": "test"})
+        expect([{"test": "test"}]).to.contain({"test": "test"}, {"test": "test"})
 
     @must_fail
     def test_contain_failure(self):
@@ -37,6 +41,10 @@ class TestContainIntegrations(TestCase):
 class TestExcludeIntegrations(TestCase):
     def test_exclude_success(self):
         expect([1, 2, 3]).to.exclude(0)
+        expect('abc').to.exclude('abcd')
+        expect('abc').to.exclude('abd', 'bcd')
+        expect([{"test": "test"}]).to.exclude({"tests": "test"})
+        expect([{"test": "test"}]).to.exclude({"tests": "test"}, {"tests": "test"})
 
     @must_fail
     def test_exclude_failure(self):

--- a/tests/matchers/test_contain.py
+++ b/tests/matchers/test_contain.py
@@ -57,18 +57,3 @@ Expected A to exclude B
     def test_register(self):
         expect(expect.matcher('contain')) == Contain
         expect(expect.matcher('exclude')) == Contain
-
-
-class TestGetFirst(TestCase):
-    def test_with_empty_set(self):
-        success, first = Contain._get_first(set())
-
-        expect(success).to.eq(False)
-        expect(first).to.eq(None)
-
-    def test_with_normal_set(self):
-        # We need to support Python 2.6, so set literal cannot be used here.
-        success, first = Contain._get_first(set([1, 2]))
-
-        expect(success).to.eq(True)
-        expect(first).to.eq(1)


### PR DESCRIPTION
### Related issues

https://github.com/vesln/robber.py/issues/16

### Description

The title says it all

### Changes
- Use `in` instead of fancy logic to make contain work properly
- Fix a bug where explanation does not show in some versions of IPython shell
- Fix a bug where tox doesn't work because of a redundant comma in setup.py
