### PR TITLE
[f] - Better message for when dict keys do not match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ install:
   - pip install coveralls
   - pip install -r requirements.txt
 python:
-  - "2.6"
   - "2.7"
   - "3.5"
   - "3.6"

--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -42,20 +42,24 @@ class Equal(Base):
 
     @property
     def dict_diffs(self):
-        if len(self.actual) != len(self.expected):
-            return 'A and B does not have the same length'
+        a_keys = self.actual.keys()
+        b_keys = self.expected.keys()
+        for key in a_keys:
+            if key not in b_keys:
+                return "A has key '%s' while B does not" % key
+        for key in b_keys:
+            if key not in a_keys:
+                return "B has key '%s' while A does not" % key
 
         for k in self.actual:
-            try:
-                val_a = self.actual[k]
-                val_b = self.expected[k]
-                if not val_a == val_b:
-                    return """Diffs:
-A['{key}'] = {val_a}
-B['{key}'] = {val_b}
-""".format(key=k, val_a=val_a, val_b=val_b)
-            except KeyError:
-                return "A has key '{k}' while B does not".format(k=k)
+            val_a = self.actual[k]
+            val_b = self.expected[k]
+            if not val_a == val_b:
+                return (
+                    'Diffs:\n'
+                    'A[\'{key}\'] = {val_a}\n'
+                    'B[\'{key}\'] = {val_b}\n'
+                ).format(key=k, val_a=val_a, val_b=val_b)
 
     @property
     def list_diffs(self):

--- a/robber/matchers/equal.py
+++ b/robber/matchers/equal.py
@@ -6,7 +6,7 @@ from robber.matchers.base import Base
 
 try:
     from collections import OrderedDict
-except ImportError:
+except ImportError:  # pragma: no cover
     ordered_dict_available = False
 else:
     ordered_dict_available = True

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if os.path.exists('README.rst'):
 
 setup(
     name='robber',
-    version='1.1.3',
+    version='1.1.4',
     description='BDD / TDD assertion library for Python',
     long_description=long_description,
     author='Tao Liang',

--- a/tests/matchers/test_equal.py
+++ b/tests/matchers/test_equal.py
@@ -22,11 +22,17 @@ class TestEqual:
 
 
 class TestDictDiff:
-    def test_dict_diffs_with_different_length(self):
+    def test_dict_diffs_with_missing_key(self):
         d1 = {'a': 1}
         d2 = {'a': 1, 'b': 2}
         equal = Equal(d1, d2)
-        expect(equal.dict_diffs).to.eq('A and B does not have the same length')
+        expect(equal.dict_diffs).to.eq("B has key 'b' while A does not")
+
+    def test_dict_diffs_with_extra_key(self):
+        d1 = {'a': 1, 'c': 3}
+        d2 = {'a': 1}
+        equal = Equal(d1, d2)
+        expect(equal.dict_diffs).to.eq("A has key 'c' while B does not")
 
     def test_dict_diffs_with_different_key(self):
         d1 = {'a': 1, 'c': 2}
@@ -38,10 +44,11 @@ class TestDictDiff:
         d1 = {'a': 1, 'b': 2}
         d2 = {'a': 1, 'b': 3}
         equal = Equal(d1, d2)
-        expect(equal.dict_diffs).to.eq("""Diffs:
-A['b'] = 2
-B['b'] = 3
-""")
+        expect(equal.dict_diffs).to.eq(
+            'Diffs:\n'
+            "A['b'] = 2\n"
+            "B['b'] = 3\n"
+        )
 
 
 class TestListDiff:

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = py26,py27,py34,py35,py36
+envlist = py27,py34,py35,py36
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py34: python3.4
     py35: python3.5


### PR DESCRIPTION
### Description

Previously when doing `expect(dict_a).to.eq(dict_b)` if the 2 dictionaries has different number of keys it will just display this unhelpful message: "A and B does not have the same length". Now it will tell which key is missing "A has key 'foo' while B does not" or "B has key 'bar' while A does not".

### Usage

```
dict_a = dict()
dict_b = {'foo': 2}
expect(dict_a).to.eq(dict_b)
# robber.bad_expectation.BadExpectation:
# B has key 'foo' while A does not
expect(dict_b).to.eq(dict_a)
# robber.bad_expectation.BadExpectation:
# A has key 'foo' while B does not
```
### Secondary changes

- **Drop support for Python 2.6**: Package `idna` which we depend on has dropped support for Python 2.6 and judging by how there's no longer a 2.6 tag for Python official image on Docker hub I think there are not many people using Python 2.6 anymore anyhow.